### PR TITLE
Add ignore list for argument-count (PLR0913) checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,3 +5,4 @@ Main
 -------
 
 - **New:** PLR0913-style checks for “too many arguments”: `argument_count_report`, `file_argument_counts`, `directory_argument_counts`, `package_argument_counts`, `check_argument_count` (default `max_args=5`, matching Ruff’s `lint.pylint.max-args`), with types `FunctionArguments` and `FileArguments`.
+- **New:** `ignore` on those APIs: skip definitions by symbol/string (including `"@macro"`), or by function/type/builtin via `nameof`. See README and the `argument_count_report` docstring for caveats (unqualified names, macros, complex types, lambdas).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CodeComplexity"
 uuid = "6a833b0f-2137-4092-987b-66bce4e6b438"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ check_argument_count("src/"; max_args=5)  # throws if any definition exceeds the
 
 Types: **`FunctionArguments`** (`name`, `arg_count`, `line`) and **`FileArguments`** (`path`, `functions`, `total_arguments`).
 
+### Ignoring definitions (`ignore`)
+
+All argument-count entry points accept optional **`ignore`**: an iterable of names or values that resolve to a name (see below). Ignored definitions are dropped **before** the `max_args` filter.
+
+```julia
+# Symbols / strings (macros use the "@name" form, e.g. "@generated")
+check_argument_count(MyPackage; max_args=5, ignore=(:legacy_api, "@my_macro"))
+
+# Functions, types / constructors, builtins — matched via nameof → same unqualified name as in source
+check_argument_count(MyPackage; max_args=5, ignore=(wide_options, MyStruct))
+```
+
+**Caveats**
+
+- Matching is by **unqualified name** only: every definition with that name is skipped, even across modules.
+- **Macros** usually have no convenient callable to pass; use `Symbol` or `String` with the stored form **`"@macroname"`**.
+- **Complex type objects** (e.g. `Union{Int,Nothing}`) use `nameof`; that string may not match a simple identifier in source—prefer symbols or strings when unsure.
+- **`->` lambdas** are reported as **`"<anonymous>"`** if you need to ignore them.
+
 ## What is cyclomatic complexity?
 
 Cyclomatic complexity counts **decision points** in the control flow (plus one). Higher values mean more branches and usually harder-to-test or harder-to-follow code.
@@ -91,11 +110,11 @@ Minimum complexity is 1 (no branches). A single `if` gives 2; each extra branch 
 | `directory_complexity(dir; recursive=true, max_complexity=nothing)` | All `.jl` files in a directory |
 | `package_complexity(pkg_or_name; max_complexity=nothing)` | All source files of a package (module or name) |
 | `check_complexity(path_or_pkg; max_complexity=10, throw_on_violation=true)` | Assert no function exceeds the limit; useful in tests/CI |
-| `argument_count_report(code; max_args=nothing)` | Parameter count per definition; optional `max_args` filter (`arg_count > max_args`) |
-| `file_argument_counts(path; max_args=nothing)` | Same as above for one file |
-| `directory_argument_counts(dir; recursive=true, max_args=nothing)` | All `.jl` files in a directory |
-| `package_argument_counts(pkg_or_name; max_args=nothing)` | All package sources |
-| `check_argument_count(path_or_pkg; max_args=5, throw_on_violation=true)` | Assert no definition exceeds the parameter limit (default 5, like Ruff) |
+| `argument_count_report(code; max_args=nothing, ignore=nothing)` | Parameter count per definition; optional `max_args` filter (`arg_count > max_args`); optional `ignore` |
+| `file_argument_counts(path; max_args=nothing, ignore=nothing)` | Same as above for one file |
+| `directory_argument_counts(dir; recursive=true, max_args=nothing, ignore=nothing)` | All `.jl` files in a directory |
+| `package_argument_counts(pkg_or_name; max_args=nothing, ignore=nothing)` | All package sources |
+| `check_argument_count(path_or_pkg; max_args=5, throw_on_violation=true, ignore=nothing)` | Assert no definition exceeds the parameter limit (default 5, like Ruff) |
 
 Types:
 

--- a/src/argument_counts.jl
+++ b/src/argument_counts.jl
@@ -45,21 +45,61 @@ function _filter_by_arg_count(
     return filter(f -> f.arg_count > max_args, functions)
 end
 
+function _argument_ignore_key(x)::String
+    if x isa Symbol || x isa AbstractString
+        return string(x)
+    elseif applicable(nameof, x)
+        return string(nameof(x))
+    else
+        return string(x)
+    end
+end
+
+function _argument_ignore_set(ignore)::Union{Nothing, Set{String}}
+    ignore === nothing && return nothing
+    return Set{String}(_argument_ignore_key(x) for x in ignore)
+end
+
+function _filter_by_ignored_names(
+    functions::Vector{FunctionArguments},
+    ignore_set::Union{Nothing, Set{String}},
+)
+    ignore_set === nothing && return functions
+    isempty(ignore_set) && return functions
+    return filter(f -> !(f.name in ignore_set), functions)
+end
+
 """
-    argument_count_report(code::AbstractString; max_args::Union{Int,Nothing}=nothing) -> Vector{FunctionArguments}
+    argument_count_report(code::AbstractString; max_args::Union{Int,Nothing}=nothing, ignore=nothing) -> Vector{FunctionArguments}
 
 Count parameters on each function-like definition in `code`. When `max_args` is set (default in
 [`check_argument_count`](@ref) is 5, matching Ruff’s `lint.pylint.max-args`), only definitions with
 `arg_count > max_args` are returned.
+
+If `ignore` is an iterable, those definitions are omitted before any `max_args` filter. Each entry is
+turned into a name string: `Symbol` / `AbstractString` use `string(x)`; any other `x` with
+`nameof(x)` defined (e.g. a `Function`, type / constructor `T`, or `Core.Builtin`) uses
+`string(nameof(x))`, matching how names appear in source. Macros still use the stored form
+`"@foo"` (e.g. `ignore=("@generated",)`). Lambdas are named `"<anonymous>"`.
+
+# Caveats
+
+- Matching is by **unqualified** name: the same name in any module is ignored.
+- **Macros** are usually passed as `Symbol` / `String` in the `"@name"` form; there is often no stable callable.
+- **Complex types** (e.g. `Union{...}`): `nameof` may not match a simple source identifier; prefer symbols/strings.
+- **`->` lambdas** use the name `"<anonymous>"` in reports and in `ignore`.
 
 See also: Ruff rule [PLR0913](https://docs.astral.sh/ruff/rules/too-many-arguments/).
 """
 function argument_count_report(
     code::AbstractString;
     max_args::Union{Int, Nothing} = nothing,
+    ignore = nothing,
 )
     expr = _parse_code(code)
     functions = _extract_argument_counts(expr)
+    ignore_set = _argument_ignore_set(ignore)
+    functions = _filter_by_ignored_names(functions, ignore_set)
     return _filter_by_arg_count(functions, max_args)
 end
 
@@ -193,24 +233,25 @@ function _extract_argument_counts(
 end
 
 """
-    file_argument_counts(filepath::AbstractString; max_args::Union{Int,Nothing}=nothing) -> FileArguments
+    file_argument_counts(filepath::AbstractString; max_args::Union{Int,Nothing}=nothing, ignore=nothing) -> FileArguments
 
 Like [`file_complexity`](@ref), but reports parameter counts per definition (PLR0913-style).
 """
 function file_argument_counts(
     filepath::AbstractString;
     max_args::Union{Int, Nothing} = nothing,
+    ignore = nothing,
 )
     if !isfile(filepath)
         throw(ArgumentError("File not found: $filepath"))
     end
     code = read(filepath, String)
-    functions = argument_count_report(code; max_args = max_args)
+    functions = argument_count_report(code; max_args = max_args, ignore = ignore)
     return FileArguments(filepath, functions)
 end
 
 """
-    directory_argument_counts(dirpath::AbstractString; recursive::Bool=true, max_args::Union{Int,Nothing}=nothing) -> Vector{FileArguments}
+    directory_argument_counts(dirpath::AbstractString; recursive::Bool=true, max_args::Union{Int,Nothing}=nothing, ignore=nothing) -> Vector{FileArguments}
 
 Like [`directory_complexity`](@ref), but for parameter-count analysis.
 """
@@ -218,6 +259,7 @@ function directory_argument_counts(
     dirpath::AbstractString;
     recursive::Bool = true,
     max_args::Union{Int, Nothing} = nothing,
+    ignore = nothing,
 )
     if !isdir(dirpath)
         throw(ArgumentError("Directory not found: $dirpath"))
@@ -231,7 +273,11 @@ function directory_argument_counts(
                 if endswith(file, ".jl")
                     filepath = joinpath(root, file)
                     try
-                        fa = file_argument_counts(filepath; max_args = max_args)
+                        fa = file_argument_counts(
+                            filepath;
+                            max_args = max_args,
+                            ignore = ignore,
+                        )
                         if max_args === nothing || !isempty(fa.functions)
                             push!(results, fa)
                         end
@@ -247,7 +293,11 @@ function directory_argument_counts(
                 filepath = joinpath(dirpath, file)
                 if isfile(filepath)
                     try
-                        fa = file_argument_counts(filepath; max_args = max_args)
+                        fa = file_argument_counts(
+                            filepath;
+                            max_args = max_args,
+                            ignore = ignore,
+                        )
                         if max_args === nothing || !isempty(fa.functions)
                             push!(results, fa)
                         end
@@ -263,27 +313,37 @@ function directory_argument_counts(
 end
 
 """
-    package_argument_counts(pkg::Module; max_args::Union{Int,Nothing}=nothing) -> Vector{FileArguments}
+    package_argument_counts(pkg::Module; max_args::Union{Int,Nothing}=nothing, ignore=nothing) -> Vector{FileArguments}
 
 Like [`package_complexity`](@ref), but for parameter counts.
 """
-function package_argument_counts(pkg::Module; max_args::Union{Int, Nothing} = nothing)
+function package_argument_counts(
+    pkg::Module;
+    max_args::Union{Int, Nothing} = nothing,
+    ignore = nothing,
+)
     pkg_path = pathof(pkg)
     if pkg_path === nothing
         throw(ArgumentError("Cannot determine source path for module $pkg"))
     end
     src_dir = dirname(pkg_path)
-    return directory_argument_counts(src_dir; recursive = true, max_args = max_args)
+    return directory_argument_counts(
+        src_dir;
+        recursive = true,
+        max_args = max_args,
+        ignore = ignore,
+    )
 end
 
 """
-    package_argument_counts(pkg_name::AbstractString; max_args::Union{Int,Nothing}=nothing) -> Vector{FileArguments}
+    package_argument_counts(pkg_name::AbstractString; max_args::Union{Int,Nothing}=nothing, ignore=nothing) -> Vector{FileArguments}
 
 Like [`package_complexity`](@ref) with a package name string, but for parameter counts.
 """
 function package_argument_counts(
     pkg_name::AbstractString;
     max_args::Union{Int, Nothing} = nothing,
+    ignore = nothing,
 )
     for depot in DEPOT_PATH
         pkg_dir = joinpath(depot, "packages", pkg_name)
@@ -296,6 +356,7 @@ function package_argument_counts(
                         latest;
                         recursive = true,
                         max_args = max_args,
+                        ignore = ignore,
                     )
                 end
             end
@@ -310,6 +371,7 @@ function package_argument_counts(
                     candidate;
                     recursive = true,
                     max_args = max_args,
+                    ignore = ignore,
                 )
             end
             candidate = joinpath(path, pkg_name)
@@ -318,6 +380,7 @@ function package_argument_counts(
                     candidate;
                     recursive = true,
                     max_args = max_args,
+                    ignore = ignore,
                 )
             end
         end
@@ -327,7 +390,7 @@ function package_argument_counts(
 end
 
 """
-    check_argument_count(path_or_pkg; max_args::Int=5, throw_on_violation::Bool=true) -> Vector{FileArguments}
+    check_argument_count(path_or_pkg; max_args::Int=5, throw_on_violation::Bool=true, ignore=nothing) -> Vector{FileArguments}
 
 Enforce a maximum parameter count per definition (Ruff PLR0913 / `lint.pylint.max-args` default: 5).
 Violations are definitions with `arg_count > max_args`.
@@ -336,6 +399,7 @@ Violations are definitions with `arg_count > max_args`.
 - `path_or_pkg`: File path, directory path, or loaded `Module`
 - `max_args::Int=5`: Allowed parameters; definitions with more are violations
 - `throw_on_violation::Bool=true`: If true, throw when any violation is found
+- `ignore`: Optional iterable of names or live callables/types to exclude (same as [`argument_count_report`](@ref); see its **Caveats** section)
 
 # Returns
 - `Vector{FileArguments}`: Files that contain violations (after filtering), or empty if none
@@ -344,12 +408,18 @@ function check_argument_count(
     path::AbstractString;
     max_args::Int = 5,
     throw_on_violation::Bool = true,
+    ignore = nothing,
 )
     violations = if isfile(path)
-        fa = file_argument_counts(path; max_args = max_args)
+        fa = file_argument_counts(path; max_args = max_args, ignore = ignore)
         isempty(fa.functions) ? FileArguments[] : [fa]
     elseif isdir(path)
-        directory_argument_counts(path; recursive = true, max_args = max_args)
+        directory_argument_counts(
+            path;
+            recursive = true,
+            max_args = max_args,
+            ignore = ignore,
+        )
     else
         throw(ArgumentError("Path not found: $path"))
     end
@@ -362,8 +432,9 @@ function check_argument_count(
     pkg::Module;
     max_args::Int = 5,
     throw_on_violation::Bool = true,
+    ignore = nothing,
 )
-    violations = package_argument_counts(pkg; max_args = max_args)
+    violations = package_argument_counts(pkg; max_args = max_args, ignore = ignore)
     _handle_argument_count_violations(violations, max_args, throw_on_violation)
     return violations
 end

--- a/test/argument_counts_tests.jl
+++ b/test/argument_counts_tests.jl
@@ -74,6 +74,79 @@
         @test viol[1].arg_count == 6
     end
 
+    @testset "ignore list" begin
+        code = """
+        function many(a,b,c,d,e,f) end
+        function few(a) end
+        macro six(a,b,c,d,e,f) end
+        """
+        r = argument_count_report(code; ignore = [:many])
+        @test length(r) == 2
+        @test Set(f.name for f in r) == Set(["few", "@six"])
+        @test !any(f -> f.name == "many", r)
+
+        viol = argument_count_report(code; max_args = 5, ignore = [:many, "@six"])
+        @test isempty(viol)
+
+        viol2 = argument_count_report(code; max_args = 5, ignore = ["@six"])
+        @test length(viol2) == 1
+        @test viol2[1].name == "many"
+
+        mktempdir() do tmpdir
+            file = joinpath(tmpdir, "ig.jl")
+            write(
+                file,
+                """
+function ok(a, b, c)
+    return a + b + c
+end
+function bad(a, b, c, d, e, f)
+    return 0
+end
+""",
+            )
+            @test isempty(
+                check_argument_count(file; max_args = 5, ignore = [:bad]),
+            )
+        end
+
+        M = Module(:IgnoreCallableTest)
+        Core.eval(
+            M,
+            quote
+                struct IgCtor end
+                function IgCtor(_a, _b, _c, _d, _e, _f)
+                    IgCtor()
+                end
+                function ig_big(_a, _b, _c, _d, _e, _f)
+                    nothing
+                end
+            end,
+        )
+        ig_big = getfield(M, :ig_big)
+        IgCtor = getfield(M, :IgCtor)
+        code_callable = """
+        struct IgCtor end
+        function IgCtor(_a, _b, _c, _d, _e, _f)
+            IgCtor()
+        end
+        function ig_big(_a, _b, _c, _d, _e, _f)
+            nothing
+        end
+        """
+        viol_c = argument_count_report(code_callable; max_args = 5)
+        @test length(viol_c) == 2
+        @test Set(f.name for f in viol_c) == Set(["IgCtor", "ig_big"])
+
+        @test isempty(
+            argument_count_report(
+                code_callable;
+                max_args = 5,
+                ignore = (ig_big, IgCtor),
+            ),
+        )
+    end
+
     @testset "FunctionArguments and FileArguments" begin
         fa = FunctionArguments("g", 7, 3)
         @test fa.name == "g" && fa.arg_count == 7 && fa.line == 3


### PR DESCRIPTION
## Summary

Adds optional `ignore` to all PLR0913-style argument-count entry points so callers can exclude specific definitions before the `max_args` filter.

## Changes

- **API:** `ignore` on `argument_count_report`, `file_argument_counts`, `directory_argument_counts`, `package_argument_counts`, and `check_argument_count`.
- **Resolution:** `Symbol` / `AbstractString` use `string(x)`; values with `nameof` (functions, types/constructors, `Core.Builtin`, etc.) use `string(nameof(x))`. Macros continue to use the stored `"@name"` form.
- **Docs:** README subsection with examples and caveats; `argument_count_report` docstring caveats; API table updated; NEWS entry.
- **Version:** `0.1.2` → `0.1.3`.

## Testing

`Pkg.test()` (155 tests + Aqua) passes locally.

---

_No `.github/pull_request_template.md` in this repo._

Made with [Cursor](https://cursor.com)