### PR TITLE
Add cognitive complexity metric (Campbell / SonarSource 2023)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,5 +4,6 @@ CodeComplexity.jl Release Notes
 Main
 -------
 
+- **New:** Cognitive complexity (G. Ann Campbell / SonarSource, 2023): `cognitive_complexity`, `cognitive_complexity_report`, `file_cognitive_complexity`, `directory_cognitive_complexity`, `package_cognitive_complexity`, `check_cognitive_complexity` (default `max_complexity=15`, matching Sonar's recommendation), with types `FunctionCognitiveComplexity` and `FileCognitiveComplexity`. Counts nested control flow, `&&`/`||` sequences, `catch`, `@goto`, and direct recursion; lambdas and nested function definitions raise the nesting level without adding their own increment.
 - **New:** PLR0913-style checks for “too many arguments”: `argument_count_report`, `file_argument_counts`, `directory_argument_counts`, `package_argument_counts`, `check_argument_count` (default `max_args=5`, matching Ruff’s `lint.pylint.max-args`), with types `FunctionArguments` and `FileArguments`.
 - **New:** `ignore` on those APIs: skip definitions by symbol/string (including `"@macro"`), or by function/type/builtin via `nameof`. See README and the `argument_count_report` docstring for caveats (unqualified names, macros, complex types, lambdas).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/charleskawczynski/CodeComplexity.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/charleskawczynski/CodeComplexity.jl/actions/workflows/ci.yml)
 
-Measure **cyclomatic complexity** of Julia code. Use it to find overly complex functions, enforce limits in tests or CI, and scan files, directories, or whole packages.
+Measure **cyclomatic complexity** and **cognitive complexity** of Julia code, plus detect **too-many-arguments** signatures. Use it to find overly complex functions, enforce limits in tests or CI, and scan files, directories, or whole packages.
 
 ## Installation
 
@@ -48,6 +48,43 @@ using MyPackage; package_complexity(MyPackage)
 check_complexity(MyPackage; max_complexity=10)  # throws if any function exceeds 10
 violations = check_complexity("src/"; max_complexity=10, throw_on_violation=false)
 ```
+
+## Cognitive complexity (Campbell / SonarSource)
+
+Cognitive complexity ([G. Ann Campbell, 2023](https://www.sonarsource.com/resources/cognitive-complexity/)) measures how hard a piece of code is to *understand*, as opposed to how many independent paths it has. It increments for breaks in linear flow, charges extra for nested flow-break structures, ignores `try` itself but counts `catch`, collapses runs of like `&&`/`||` into one increment, and adds one for direct recursion.
+
+```julia
+cognitive_complexity("""
+function sumOfPrimes(maxv)
+    total = 0
+    for i in 1:maxv          # +1
+        for j in 2:(i-1)     # +2 (nesting=1)
+            if i % j == 0    # +3 (nesting=2)
+                @goto out    # +1
+            end
+        end
+        total += i
+        @label out
+    end
+    return total
+end
+""")  # 7
+
+cognitive_complexity_report(read("src/MyModule.jl", String))
+file_cognitive_complexity("src/MyModule.jl"; max_complexity=15)
+directory_cognitive_complexity("src/"; max_complexity=15)
+package_cognitive_complexity(CodeComplexity; max_complexity=15)
+
+check_cognitive_complexity(MyPackage; max_complexity=15)  # SonarSource's recommended limit
+```
+
+Types: **`FunctionCognitiveComplexity`** (`name`, `complexity`, `line`) and **`FileCognitiveComplexity`** (`path`, `functions`, `total_complexity`).
+
+A few Julia-specific notes:
+
+- `cond ? a : b` and `if cond; a; else b end` parse to the *same* `:if` AST node, so the ternary operator is reported as if/else (`+1` for the `if` plus `+1` for the `else`) rather than the spec's single-increment ternary rule.
+- Direct recursion is detected by name; **indirect recursion** and calls through dotted names (e.g. `M.foo`) are not counted.
+- Comprehensions/generators are walked as plain expressions; nested `if`/`for` *inside* a comprehension do not add structural increments.
 
 ## Too many arguments (Ruff PLR0913–style)
 
@@ -110,6 +147,12 @@ Minimum complexity is 1 (no branches). A single `if` gives 2; each extra branch 
 | `directory_complexity(dir; recursive=true, max_complexity=nothing)` | All `.jl` files in a directory |
 | `package_complexity(pkg_or_name; max_complexity=nothing)` | All source files of a package (module or name) |
 | `check_complexity(path_or_pkg; max_complexity=10, throw_on_violation=true)` | Assert no function exceeds the limit; useful in tests/CI |
+| `cognitive_complexity(expr)` / `cognitive_complexity(code::String)` | Cognitive complexity (Campbell / SonarSource) of one expression or code string |
+| `cognitive_complexity_report(code; max_complexity=nothing)` | Per-function cognitive complexity for code string; optional threshold filter |
+| `file_cognitive_complexity(path; max_complexity=nothing)` | Per-function cognitive complexity for a file |
+| `directory_cognitive_complexity(dir; recursive=true, max_complexity=nothing)` | All `.jl` files in a directory |
+| `package_cognitive_complexity(pkg_or_name; max_complexity=nothing)` | All source files of a package |
+| `check_cognitive_complexity(path_or_pkg; max_complexity=15, throw_on_violation=true)` | Assert no function exceeds the cognitive limit (default 15, SonarSource's recommendation) |
 | `argument_count_report(code; max_args=nothing, ignore=nothing)` | Parameter count per definition; optional `max_args` filter (`arg_count > max_args`); optional `ignore` |
 | `file_argument_counts(path; max_args=nothing, ignore=nothing)` | Same as above for one file |
 | `directory_argument_counts(dir; recursive=true, max_args=nothing, ignore=nothing)` | All `.jl` files in a directory |
@@ -120,6 +163,8 @@ Types:
 
 - **`FunctionComplexity`**: `name`, `complexity`, `line`
 - **`FileComplexity`**: `path`, `functions`, `total_complexity`
+- **`FunctionCognitiveComplexity`**: `name`, `complexity`, `line`
+- **`FileCognitiveComplexity`**: `path`, `functions`, `total_complexity`
 - **`FunctionArguments`**: `name`, `arg_count`, `line`
 - **`FileArguments`**: `path`, `functions`, `total_arguments`
 

--- a/src/CodeComplexity.jl
+++ b/src/CodeComplexity.jl
@@ -5,6 +5,7 @@ using JuliaSyntax
 include("ast_utils.jl")
 include("cyclomatic_complexity.jl")
 include("argument_counts.jl")
+include("cognitive_complexity.jl")
 
 export cyclomatic_complexity,
     complexity_report,
@@ -20,6 +21,14 @@ export cyclomatic_complexity,
     package_argument_counts,
     check_argument_count,
     FunctionArguments,
-    FileArguments
+    FileArguments,
+    cognitive_complexity,
+    cognitive_complexity_report,
+    file_cognitive_complexity,
+    directory_cognitive_complexity,
+    package_cognitive_complexity,
+    check_cognitive_complexity,
+    FunctionCognitiveComplexity,
+    FileCognitiveComplexity
 
 end # module CodeComplexity

--- a/src/cognitive_complexity.jl
+++ b/src/cognitive_complexity.jl
@@ -1,0 +1,589 @@
+# Cognitive Complexity per G. Ann Campbell, "Cognitive Complexity – a new way of
+# measuring understandability" (SonarSource, v1.7, 2023).
+#
+# Differences from the white paper that are forced by Julia's AST representation:
+#   * `cond ? a : b` and `if cond; a; else b end` parse to the same `:if` node, so
+#     the ternary operator gets the if/else treatment (`+1` for the if and `+1`
+#     for the else) rather than the paper's single-increment ternary rule.
+#   * `&&` / `||` are parsed as nested binary nodes; we collapse a chain of
+#     identical operators into a single "sequence" so `a && b && c` counts as
+#     one increment, while `a && b || c` counts as two (matching the spec).
+
+"""
+    FunctionCognitiveComplexity
+
+Per-function cognitive complexity score (Sonar/Campbell 2023).
+
+# Fields
+- `name::String`: Function (or macro) name; `"<anonymous>"` for `->` lambdas
+- `complexity::Int`: Cognitive complexity score (>= 0)
+- `line::Int`: Line of the definition (0 if unknown)
+"""
+struct FunctionCognitiveComplexity
+    name::String
+    complexity::Int
+    line::Int
+end
+
+"""
+    FileCognitiveComplexity
+
+Cognitive-complexity summary for a source file.
+
+# Fields
+- `path::String`: File path
+- `functions::Vector{FunctionCognitiveComplexity}`: One entry per definition
+- `total_complexity::Int`: Sum of `complexity` over `functions`
+"""
+struct FileCognitiveComplexity
+    path::String
+    functions::Vector{FunctionCognitiveComplexity}
+    total_complexity::Int
+end
+
+function FileCognitiveComplexity(
+    path::String,
+    functions::Vector{FunctionCognitiveComplexity},
+)
+    total = sum(f.complexity for f in functions; init = 0)
+    FileCognitiveComplexity(path, functions, total)
+end
+
+"""
+    cognitive_complexity(expr) -> Int
+    cognitive_complexity(code::AbstractString) -> Int
+
+Compute the cognitive complexity of a Julia expression or code string.
+
+Cognitive complexity rewards code that reads top-to-bottom and penalises
+nesting and "shape changes". Increments come from:
+
+- `if`, `elseif`, `else`, ternary (`? :`)
+- `for`, `while` loops
+- `catch` clauses (the `try` block itself is free)
+- Each new sequence of like binary boolean operators (`&&` / `||`)
+- `@goto`
+- A function that calls itself (direct recursion)
+- Each level of nesting inside a control-flow structure
+
+Lambdas and nested `function`/`macro` definitions are not counted as increments
+themselves, but they raise the nesting level for their body.
+
+A function with no decisions has complexity 0 (unlike cyclomatic complexity,
+which has a base of 1).
+"""
+function cognitive_complexity(expr)
+    return _cognitive_walk(expr, 0, false)
+end
+
+function cognitive_complexity(code::AbstractString)
+    return cognitive_complexity(_parse_code(code))
+end
+
+# Main dispatch: nesting is the depth inside structural control-flow; in_func
+# is true once we're already inside a function/lambda body so a further
+# function/lambda is treated as nested.
+function _cognitive_walk(expr, nesting::Int, in_func::Bool)
+    expr isa Expr || return 0
+    return _cognitive_for_head(Val(expr.head), expr, nesting, in_func)
+end
+
+function _walk_args(args, nesting::Int, in_func::Bool)
+    c = 0
+    for a in args
+        c += _cognitive_walk(a, nesting, in_func)
+    end
+    return c
+end
+
+_cognitive_for_head(::Val, expr::Expr, nesting, in_func) =
+    _walk_args(expr.args, nesting, in_func)
+
+# --- function-like definitions ---------------------------------------------
+
+function _cognitive_for_head(::Val{:function}, expr::Expr, nesting, in_func)
+    return _walk_funclike_body(expr, 2, nesting, in_func; check_recursion = true)
+end
+
+function _cognitive_for_head(::Val{:macro}, expr::Expr, nesting, in_func)
+    return _walk_funclike_body(expr, 2, nesting, in_func; check_recursion = false)
+end
+
+function _cognitive_for_head(::Val{:->}, expr::Expr, nesting, in_func)
+    return _walk_funclike_body(expr, 2, nesting, in_func; check_recursion = false)
+end
+
+function _cognitive_for_head(::Val{:(=)}, expr::Expr, nesting, in_func)
+    if _is_short_function(expr)
+        return _walk_funclike_body(expr, 2, nesting, in_func; check_recursion = true)
+    end
+    return _walk_args(expr.args, nesting, in_func)
+end
+
+function _is_short_function(expr::Expr)
+    expr.head === :(=) || return false
+    length(expr.args) >= 1 || return false
+    a1 = expr.args[1]
+    a1 isa Expr || return false
+    return a1.head === :call || a1.head === :where
+end
+
+function _walk_funclike_body(
+    expr::Expr,
+    body_idx::Int,
+    nesting::Int,
+    in_func::Bool;
+    check_recursion::Bool,
+)
+    length(expr.args) >= body_idx || return 0
+    body = expr.args[body_idx]
+    body_nesting = in_func ? nesting + 1 : nesting
+    c = _cognitive_walk(body, body_nesting, true)
+    if check_recursion
+        name, is_func = _get_function_name(expr)
+        if is_func && _has_recursive_call(body, name)
+            c += 1
+        end
+    end
+    return c
+end
+
+# --- conditionals ----------------------------------------------------------
+
+function _cognitive_for_head(::Val{:if}, expr::Expr, nesting, in_func)
+    return _walk_if_like(expr.args, nesting, in_func; structural = true)
+end
+
+function _cognitive_for_head(::Val{:elseif}, expr::Expr, nesting, in_func)
+    return _walk_if_like(expr.args, nesting, in_func; structural = false)
+end
+
+function _walk_if_like(args, nesting::Int, in_func::Bool; structural::Bool)
+    n = length(args)
+    n >= 1 || return 0
+    cond = args[1]
+    then_branch = n >= 2 ? args[2] : nothing
+    else_branch = n >= 3 ? args[3] : nothing
+
+    has_elif = else_branch isa Expr && else_branch.head === :elseif
+    has_else = else_branch !== nothing && !has_elif
+
+    # Structural increment for `if` (subject to nesting); hybrid for `elseif`.
+    base = structural ? 1 + nesting : 1
+    base += has_else ? 1 : 0
+
+    inner_nesting = nesting + 1
+    c = _cognitive_walk(cond, inner_nesting, in_func)
+    if then_branch !== nothing
+        c += _cognitive_walk(then_branch, inner_nesting, in_func)
+    end
+    if else_branch !== nothing
+        if has_elif
+            # Pass through `elseif` at the same nesting (no nesting increment
+            # for the `elseif`/`else` keywords themselves).
+            c += _cognitive_walk(else_branch, nesting, in_func)
+        else
+            c += _cognitive_walk(else_branch, inner_nesting, in_func)
+        end
+    end
+    return base + c
+end
+
+# --- loops -----------------------------------------------------------------
+
+function _cognitive_for_head(::Val{:for}, expr::Expr, nesting, in_func)
+    return _walk_loop(expr.args, nesting, in_func)
+end
+
+function _cognitive_for_head(::Val{:while}, expr::Expr, nesting, in_func)
+    return _walk_loop(expr.args, nesting, in_func)
+end
+
+function _walk_loop(args, nesting::Int, in_func::Bool)
+    base = 1 + nesting
+    return base + _walk_args(args, nesting + 1, in_func)
+end
+
+# --- try / catch -----------------------------------------------------------
+
+function _cognitive_for_head(::Val{:try}, expr::Expr, nesting, in_func)
+    args = expr.args
+    n = length(args)
+    c = 0
+    if n >= 1 && args[1] isa Expr
+        c += _cognitive_walk(args[1], nesting, in_func)
+    end
+    if n >= 3 && args[3] isa Expr
+        # +1 (subject to nesting) for the catch; nesting+1 for the catch body.
+        c += 1 + nesting
+        c += _cognitive_walk(args[3], nesting + 1, in_func)
+    end
+    if n >= 4 && args[4] isa Expr
+        c += _cognitive_walk(args[4], nesting, in_func)
+    end
+    if n >= 5 && args[5] isa Expr
+        c += _cognitive_walk(args[5], nesting, in_func)
+    end
+    return c
+end
+
+# --- short-circuit boolean sequences ---------------------------------------
+
+function _cognitive_for_head(::Val{:&&}, expr::Expr, nesting, in_func)
+    return _walk_boolop_sequence(expr, nesting, in_func, expr.head; new_sequence = true)
+end
+
+function _cognitive_for_head(::Val{:||}, expr::Expr, nesting, in_func)
+    return _walk_boolop_sequence(expr, nesting, in_func, expr.head; new_sequence = true)
+end
+
+# Counts each maximal run of identical short-circuit operators as one
+# fundamental increment, matching the white paper's "sequence of like
+# binary boolean operators" rule.
+function _walk_boolop_sequence(
+    expr::Expr,
+    nesting::Int,
+    in_func::Bool,
+    seq_head::Symbol;
+    new_sequence::Bool,
+)
+    c = new_sequence ? 1 : 0
+    for a in expr.args
+        if a isa Expr && (a.head === :&& || a.head === :||)
+            if a.head === seq_head
+                c += _walk_boolop_sequence(
+                    a,
+                    nesting,
+                    in_func,
+                    seq_head;
+                    new_sequence = false,
+                )
+            else
+                c += _walk_boolop_sequence(
+                    a,
+                    nesting,
+                    in_func,
+                    a.head;
+                    new_sequence = true,
+                )
+            end
+        else
+            c += _cognitive_walk(a, nesting, in_func)
+        end
+    end
+    return c
+end
+
+# --- @goto and other macro calls -------------------------------------------
+
+function _cognitive_for_head(::Val{:macrocall}, expr::Expr, nesting, in_func)
+    args = expr.args
+    c = 0
+    if !isempty(args) && args[1] === Symbol("@goto")
+        c += 1
+    end
+    # args[1] is the macro name and args[2] is a LineNumberNode; only walk the
+    # macro arguments themselves.
+    for i in 3:length(args)
+        c += _cognitive_walk(args[i], nesting, in_func)
+    end
+    return c
+end
+
+# --- recursion detection ---------------------------------------------------
+
+function _has_recursive_call(body, name::AbstractString)
+    isempty(name) && return false
+    occursin(".", name) && return false
+    target = Symbol(name)
+    return _contains_call_to(body, target)
+end
+
+function _contains_call_to(expr, target::Symbol)
+    expr isa Expr || return false
+    if expr.head === :call &&
+       length(expr.args) >= 1 &&
+       expr.args[1] === target
+        return true
+    end
+    for a in expr.args
+        _contains_call_to(a, target) && return true
+    end
+    return false
+end
+
+# --- reports / file-walking utilities --------------------------------------
+
+function _filter_by_cognitive_complexity(
+    functions::Vector{FunctionCognitiveComplexity},
+    max_complexity::Union{Int, Nothing},
+)
+    max_complexity === nothing && return functions
+    return filter(f -> f.complexity > max_complexity, functions)
+end
+
+"""
+    cognitive_complexity_report(code::AbstractString; max_complexity=nothing)
+        -> Vector{FunctionCognitiveComplexity}
+
+Cognitive complexity for each top-level definition in `code`. When
+`max_complexity` is set, only definitions with `complexity > max_complexity`
+are returned.
+"""
+function cognitive_complexity_report(
+    code::AbstractString;
+    max_complexity::Union{Int, Nothing} = nothing,
+)
+    expr = _parse_code(code)
+    functions = _extract_cognitive_complexities(expr)
+    return _filter_by_cognitive_complexity(functions, max_complexity)
+end
+
+function _extract_cognitive_complexities(
+    expr,
+    results::Vector{FunctionCognitiveComplexity} = FunctionCognitiveComplexity[],
+)
+    if expr isa Expr
+        if expr.head === :function || expr.head === :(=)
+            name, is_func = _get_function_name(expr)
+            if is_func
+                comp = cognitive_complexity(expr)
+                line = _get_line_number(expr)
+                push!(results, FunctionCognitiveComplexity(name, comp, line))
+            else
+                for arg in expr.args
+                    _extract_cognitive_complexities(arg, results)
+                end
+            end
+        elseif expr.head === :->
+            comp = cognitive_complexity(expr)
+            line = _get_line_number(expr)
+            push!(results, FunctionCognitiveComplexity("<anonymous>", comp, line))
+        elseif expr.head === :macro
+            if length(expr.args) >= 1
+                name = "@" * string(_extract_name(expr.args[1]))
+                comp = cognitive_complexity(expr)
+                line = _get_line_number(expr)
+                push!(results, FunctionCognitiveComplexity(name, comp, line))
+            end
+        else
+            for arg in expr.args
+                _extract_cognitive_complexities(arg, results)
+            end
+        end
+    end
+    return results
+end
+
+"""
+    file_cognitive_complexity(filepath; max_complexity=nothing) -> FileCognitiveComplexity
+
+Like [`file_complexity`](@ref) but reports cognitive complexity per definition.
+"""
+function file_cognitive_complexity(
+    filepath::AbstractString;
+    max_complexity::Union{Int, Nothing} = nothing,
+)
+    if !isfile(filepath)
+        throw(ArgumentError("File not found: $filepath"))
+    end
+    code = read(filepath, String)
+    functions = cognitive_complexity_report(code; max_complexity = max_complexity)
+    return FileCognitiveComplexity(filepath, functions)
+end
+
+"""
+    directory_cognitive_complexity(dirpath; recursive=true, max_complexity=nothing)
+        -> Vector{FileCognitiveComplexity}
+
+Like [`directory_complexity`](@ref) but for cognitive complexity.
+"""
+function directory_cognitive_complexity(
+    dirpath::AbstractString;
+    recursive::Bool = true,
+    max_complexity::Union{Int, Nothing} = nothing,
+)
+    if !isdir(dirpath)
+        throw(ArgumentError("Directory not found: $dirpath"))
+    end
+
+    results = FileCognitiveComplexity[]
+    paths = _collect_jl_files(dirpath, recursive)
+    for filepath in paths
+        try
+            fc = file_cognitive_complexity(filepath; max_complexity = max_complexity)
+            if max_complexity === nothing || !isempty(fc.functions)
+                push!(results, fc)
+            end
+        catch e
+            @warn "Failed to analyze $filepath" exception = e
+        end
+    end
+    return results
+end
+
+function _collect_jl_files(dirpath::AbstractString, recursive::Bool)
+    paths = String[]
+    if recursive
+        for (root, _, files) in walkdir(dirpath)
+            for file in files
+                endswith(file, ".jl") && push!(paths, joinpath(root, file))
+            end
+        end
+    else
+        for file in readdir(dirpath)
+            endswith(file, ".jl") || continue
+            filepath = joinpath(dirpath, file)
+            isfile(filepath) && push!(paths, filepath)
+        end
+    end
+    return paths
+end
+
+"""
+    package_cognitive_complexity(pkg; max_complexity=nothing) -> Vector{FileCognitiveComplexity}
+
+Like [`package_complexity`](@ref) but for cognitive complexity. Accepts either
+a loaded `Module` or a package name string.
+"""
+function package_cognitive_complexity(
+    pkg::Module;
+    max_complexity::Union{Int, Nothing} = nothing,
+)
+    pkg_path = pathof(pkg)
+    if pkg_path === nothing
+        throw(ArgumentError("Cannot determine source path for module $pkg"))
+    end
+    src_dir = dirname(pkg_path)
+    return directory_cognitive_complexity(
+        src_dir;
+        recursive = true,
+        max_complexity = max_complexity,
+    )
+end
+
+function package_cognitive_complexity(
+    pkg_name::AbstractString;
+    max_complexity::Union{Int, Nothing} = nothing,
+)
+    for depot in DEPOT_PATH
+        pkg_dir = joinpath(depot, "packages", pkg_name)
+        if isdir(pkg_dir)
+            versions = readdir(pkg_dir)
+            if !isempty(versions)
+                latest = joinpath(pkg_dir, last(sort(versions)), "src")
+                if isdir(latest)
+                    return directory_cognitive_complexity(
+                        latest;
+                        recursive = true,
+                        max_complexity = max_complexity,
+                    )
+                end
+            end
+        end
+    end
+
+    for path in LOAD_PATH
+        if path isa AbstractString
+            candidate = joinpath(path, pkg_name, "src")
+            if isdir(candidate)
+                return directory_cognitive_complexity(
+                    candidate;
+                    recursive = true,
+                    max_complexity = max_complexity,
+                )
+            end
+            candidate = joinpath(path, pkg_name)
+            if isdir(candidate)
+                return directory_cognitive_complexity(
+                    candidate;
+                    recursive = true,
+                    max_complexity = max_complexity,
+                )
+            end
+        end
+    end
+
+    throw(ArgumentError("Package not found: $pkg_name"))
+end
+
+"""
+    check_cognitive_complexity(path_or_pkg; max_complexity=15, throw_on_violation=true)
+        -> Vector{FileCognitiveComplexity}
+
+Assert that no function exceeds the given cognitive-complexity threshold
+(SonarSource recommends 15). Mirrors [`check_complexity`](@ref).
+"""
+function check_cognitive_complexity(
+    path::AbstractString;
+    max_complexity::Int = 15,
+    throw_on_violation::Bool = true,
+)
+    violations = if isfile(path)
+        fc = file_cognitive_complexity(path; max_complexity = max_complexity)
+        isempty(fc.functions) ? FileCognitiveComplexity[] : [fc]
+    elseif isdir(path)
+        directory_cognitive_complexity(
+            path;
+            recursive = true,
+            max_complexity = max_complexity,
+        )
+    else
+        throw(ArgumentError("Path not found: $path"))
+    end
+
+    _handle_cognitive_violations(violations, max_complexity, throw_on_violation)
+    return violations
+end
+
+function check_cognitive_complexity(
+    pkg::Module;
+    max_complexity::Int = 15,
+    throw_on_violation::Bool = true,
+)
+    violations = package_cognitive_complexity(pkg; max_complexity = max_complexity)
+    _handle_cognitive_violations(violations, max_complexity, throw_on_violation)
+    return violations
+end
+
+function _handle_cognitive_violations(
+    violations::Vector{FileCognitiveComplexity},
+    max_complexity::Int,
+    throw_on_violation::Bool,
+)
+    if throw_on_violation && !isempty(violations)
+        msg = IOBuffer()
+        println(
+            msg,
+            "Cognitive complexity violations (max_complexity=$max_complexity):",
+        )
+        for fc in violations
+            for func in fc.functions
+                line_info = func.line > 0 ? ":$(func.line)" : ""
+                println(
+                    msg,
+                    "  $(fc.path)$line_info: $(func.name) has complexity $(func.complexity)",
+                )
+            end
+        end
+        error(String(take!(msg)))
+    end
+end
+
+function Base.show(io::IO, fc::FunctionCognitiveComplexity)
+    line_info = fc.line > 0 ? " (line $(fc.line))" : ""
+    print(
+        io,
+        "FunctionCognitiveComplexity(\"$(fc.name)\", complexity=$(fc.complexity)$line_info)",
+    )
+end
+
+function Base.show(io::IO, ::MIME"text/plain", fc::FileCognitiveComplexity)
+    println(io, "FileCognitiveComplexity: $(fc.path)")
+    println(io, "  Total cognitive complexity: $(fc.total_complexity)")
+    println(io, "  Functions ($(length(fc.functions))):")
+    for func in fc.functions
+        line_info = func.line > 0 ? " (line $(func.line))" : ""
+        println(io, "    $(func.name): $(func.complexity)$line_info")
+    end
+end

--- a/test/cognitive_complexity_tests.jl
+++ b/test/cognitive_complexity_tests.jl
@@ -1,0 +1,615 @@
+# Included from runtests.jl — cognitive complexity metric, reports, and check_cognitive_complexity.
+
+@testset "Cognitive: trivial cases" begin
+    @testset "trivial function" begin
+        code = """
+        function trivial()
+            return nothing
+        end
+        """
+        @test cognitive_complexity(code) == 0
+    end
+
+    @testset "sequential statements" begin
+        code = """
+        function sequential(n)
+            k = n + 4
+            s = k + n
+            return s
+        end
+        """
+        @test cognitive_complexity(code) == 0
+    end
+
+    @testset "short form function" begin
+        @test cognitive_complexity("f(x) = x + 1") == 0
+    end
+end
+
+@testset "Cognitive: if/elseif/else" begin
+    @testset "simple if" begin
+        code = """
+        function f(x)
+            if x > 0
+                return x
+            end
+        end
+        """
+        @test cognitive_complexity(code) == 1
+    end
+
+    @testset "if-else (+1 hybrid for else)" begin
+        code = """
+        function f(x)
+            if x > 0
+                return x
+            else
+                return -x
+            end
+        end
+        """
+        @test cognitive_complexity(code) == 2
+    end
+
+    @testset "if-elseif (+1 each)" begin
+        code = """
+        function f(x)
+            if x > 0
+                return 1
+            elseif x < 0
+                return -1
+            end
+        end
+        """
+        @test cognitive_complexity(code) == 2
+    end
+
+    @testset "if-elseif-else" begin
+        code = """
+        function f(x)
+            if x == 1
+                return "one"
+            elseif x == 2
+                return "two"
+            else
+                return "other"
+            end
+        end
+        """
+        @test cognitive_complexity(code) == 3
+    end
+
+    @testset "nested if (nesting increment)" begin
+        code = """
+        function f(x, y)
+            if x > 0
+                if y > 0
+                    return x + y
+                end
+            end
+        end
+        """
+        # outer if: +1, inner if: +1+1 nesting = +2 → total 3
+        @test cognitive_complexity(code) == 3
+    end
+
+    @testset "deeply nested ifs" begin
+        code = """
+        function f(a, b, c)
+            if a > 0
+                if b > 0
+                    if c > 0
+                        return 1
+                    end
+                end
+            end
+        end
+        """
+        # +1, +2, +3 → 6
+        @test cognitive_complexity(code) == 6
+    end
+end
+
+@testset "Cognitive: loops" begin
+    @testset "single for" begin
+        code = """
+        function f()
+            for i in 1:10
+                println(i)
+            end
+        end
+        """
+        @test cognitive_complexity(code) == 1
+    end
+
+    @testset "nested for" begin
+        code = """
+        function f()
+            for i in 1:10
+                for j in 1:10
+                    println(i*j)
+                end
+            end
+        end
+        """
+        # +1 + (+1+1) = 3
+        @test cognitive_complexity(code) == 3
+    end
+
+    @testset "triple nested for" begin
+        code = """
+        function f()
+            for i in 1:10
+                for j in 1:10
+                    for k in 1:10
+                        println(i*j*k)
+                    end
+                end
+            end
+        end
+        """
+        # +1 + +2 + +3 = 6
+        @test cognitive_complexity(code) == 6
+    end
+
+    @testset "while" begin
+        code = """
+        function f(n)
+            while n > 0
+                n -= 1
+            end
+        end
+        """
+        @test cognitive_complexity(code) == 1
+    end
+
+    @testset "for with if (nesting)" begin
+        code = """
+        function f(items)
+            for item in items
+                if item > 0
+                    println(item)
+                end
+            end
+        end
+        """
+        # +1 for + (+1+1 if nested) = 3
+        @test cognitive_complexity(code) == 3
+    end
+end
+
+@testset "Cognitive: short-circuit boolean sequences" begin
+    @testset "single &&" begin
+        @test cognitive_complexity("a && b") == 1
+    end
+
+    @testset "chained && counts as one sequence" begin
+        @test cognitive_complexity("a && b && c") == 1
+        @test cognitive_complexity("a && b && c && d") == 1
+    end
+
+    @testset "chained || counts as one sequence" begin
+        @test cognitive_complexity("a || b || c || d") == 1
+    end
+
+    @testset "mixed && and || → two sequences" begin
+        @test cognitive_complexity("a && b || c") == 2
+        @test cognitive_complexity("a || b && c") == 2
+    end
+
+    @testset "negation does not collapse sequences" begin
+        # Whitepaper example: a && !(b && c) → 2
+        @test cognitive_complexity("a && !(b && c)") == 2
+    end
+
+    @testset "if with boolean condition" begin
+        code = """
+        function f(a, b, c)
+            if a && b && c
+                return 1
+            end
+        end
+        """
+        # +1 if + +1 single && sequence = 2
+        @test cognitive_complexity(code) == 2
+    end
+
+    @testset "if with mixed boolean condition" begin
+        code = """
+        function f(a, b, c, d)
+            if a && b || c && d
+                return 1
+            end
+        end
+        """
+        # +1 if + sequences (||, &&, &&) = 1 + 3 = 4. Right-assoc: ||(&&(a,b), &&(c,d)) → top || (+1), each && (+1 each) = 3 sequences.
+        @test cognitive_complexity(code) == 4
+    end
+end
+
+@testset "Cognitive: ternary" begin
+    @testset "simple ternary" begin
+        # Note: Julia's parser converts `a ? b : c` to an `if … else … end` AST node,
+        # so we report it as if/else (+1 if, +1 else) rather than the paper's
+        # single-increment ternary rule.
+        @test cognitive_complexity("x > 0 ? x : -x") == 2
+    end
+
+    @testset "nested ternary" begin
+        # outer if/else: +2 (top-level), inner if/else inside else branch: +2 nested + +1 hybrid = 4? Let's compute:
+        # outer if at 0: base = 1+0+1(else) = 2. then-branch nesting=1.
+        # else-branch: nested ternary → if at nesting=1: base = 1+1+1(else)=3. → total 5.
+        @test cognitive_complexity("x > 0 ? x : (y > 0 ? y : -y)") == 5
+    end
+end
+
+@testset "Cognitive: try/catch" begin
+    @testset "try without catch is free" begin
+        code = """
+        function f()
+            try
+                a()
+            finally
+                b()
+            end
+        end
+        """
+        @test cognitive_complexity(code) == 0
+    end
+
+    @testset "try with catch" begin
+        code = """
+        function f()
+            try
+                a()
+            catch
+                b()
+            end
+        end
+        """
+        @test cognitive_complexity(code) == 1
+    end
+
+    @testset "catch with nested if (whitepaper-style)" begin
+        # void myMethod () { try { if (c1) { for { while {…} } } } catch { if (c2) … } }
+        # → 1 + 2 + 3 + 1 + 2 = 9
+        code = """
+        function myMethod()
+            try
+                if condition1
+                    for i in 1:10
+                        while condition2
+                            doit()
+                        end
+                    end
+                end
+            catch
+                if condition2
+                    handle()
+                end
+            end
+        end
+        """
+        @test cognitive_complexity(code) == 9
+    end
+end
+
+@testset "Cognitive: recursion" begin
+    @testset "self-recursive function adds +1" begin
+        code = """
+        function fact(n)
+            if n <= 1
+                return 1
+            else
+                return n * fact(n - 1)
+            end
+        end
+        """
+        # if/else: 2; recursion: +1 → 3
+        @test cognitive_complexity(code) == 3
+    end
+
+    @testset "non-recursive identical shape" begin
+        code = """
+        function abs_val(x)
+            if x > 0
+                return x
+            else
+                return -x
+            end
+        end
+        """
+        @test cognitive_complexity(code) == 2
+    end
+
+    @testset "short-form recursion" begin
+        @test cognitive_complexity("f(n) = n <= 1 ? 1 : n * f(n - 1)") == 3
+    end
+end
+
+@testset "Cognitive: @goto" begin
+    code = """
+    function loop()
+        for i in 1:10
+            for j in 1:10
+                if i == j
+                    @goto out
+                end
+            end
+        end
+        @label out
+        return nothing
+    end
+    """
+    # for(+1) + for(+2) + if(+3) + @goto(+1) = 7  (matches sumOfPrimes example from spec)
+    @test cognitive_complexity(code) == 7
+end
+
+@testset "Cognitive: lambdas and nested functions" begin
+    @testset "lambda inside function adds nesting" begin
+        code = """
+        function myMethod()
+            r = () -> begin
+                if condition1
+                    something()
+                end
+            end
+        end
+        """
+        # Lambda body if: +1 + 1 nesting = 2
+        @test cognitive_complexity(code) == 2
+    end
+
+    @testset "top-level lambda body counted at nesting 0" begin
+        @test cognitive_complexity("x -> x > 0 ? x : -x") == 2
+    end
+
+    @testset "nested function adds nesting" begin
+        code = """
+        function outer()
+            function inner()
+                if x
+                end
+            end
+        end
+        """
+        @test cognitive_complexity(code) == 2
+    end
+end
+
+@testset "cognitive_complexity_report" begin
+    @testset "multiple functions" begin
+        code = """
+        function trivial()
+            return 1
+        end
+
+        function with_if(x)
+            if x > 0
+                return x
+            end
+        end
+
+        function with_loop_and_if(items)
+            for item in items
+                if item > 0
+                    println(item)
+                end
+            end
+        end
+        """
+        report = cognitive_complexity_report(code)
+        @test length(report) == 3
+        d = Dict(r.name => r.complexity for r in report)
+        @test d["trivial"] == 0
+        @test d["with_if"] == 1
+        @test d["with_loop_and_if"] == 3
+    end
+
+    @testset "macro definitions" begin
+        code = """
+        macro simple(x)
+            return x
+        end
+
+        macro with_if(x)
+            if x isa Symbol
+                return x
+            else
+                return :(nothing)
+            end
+        end
+        """
+        report = cognitive_complexity_report(code)
+        @test length(report) == 2
+        d = Dict(r.name => r.complexity for r in report)
+        @test d["@simple"] == 0
+        @test d["@with_if"] == 2
+    end
+
+    @testset "anonymous function" begin
+        code = "f = x -> x > 0 ? x : -x"
+        report = cognitive_complexity_report(code)
+        @test length(report) == 1
+        @test report[1].name == "<anonymous>"
+        @test report[1].complexity == 2
+    end
+
+    @testset "max_complexity filter" begin
+        code = """
+        function low()
+            return 1
+        end
+
+        function high(a, b, c)
+            if a > 0
+                if b > 0
+                    if c > 0
+                        return 1
+                    end
+                end
+            end
+        end
+        """
+        # high cognitive: 1+2+3 = 6
+        all_report = cognitive_complexity_report(code)
+        @test length(all_report) == 2
+
+        filtered = cognitive_complexity_report(code; max_complexity = 3)
+        @test length(filtered) == 1
+        @test filtered[1].name == "high"
+        @test filtered[1].complexity == 6
+
+        @test isempty(cognitive_complexity_report(code; max_complexity = 100))
+    end
+end
+
+@testset "FunctionCognitiveComplexity / FileCognitiveComplexity" begin
+    f = FunctionCognitiveComplexity("foo", 7, 12)
+    @test f.name == "foo"
+    @test f.complexity == 7
+    @test f.line == 12
+
+    io = IOBuffer()
+    show(io, f)
+    out = String(take!(io))
+    @test occursin("foo", out)
+    @test occursin("7", out)
+
+    fc = FileCognitiveComplexity(
+        "x.jl",
+        [
+            FunctionCognitiveComplexity("a", 2, 1),
+            FunctionCognitiveComplexity("b", 5, 10),
+        ],
+    )
+    @test fc.path == "x.jl"
+    @test fc.total_complexity == 7
+end
+
+@testset "file/directory/check cognitive_complexity" begin
+    mktempdir() do tmpdir
+        good = joinpath(tmpdir, "good.jl")
+        write(
+            good,
+            """
+function ok(x)
+    return x + 1
+end
+""",
+        )
+
+        bad = joinpath(tmpdir, "bad.jl")
+        write(
+            bad,
+            """
+function nested(a, b, c)
+    if a > 0
+        if b > 0
+            if c > 0
+                return 1
+            end
+        end
+    end
+    return 0
+end
+""",
+        )
+
+        @testset "file_cognitive_complexity" begin
+            fc = file_cognitive_complexity(good)
+            @test fc.path == good
+            @test length(fc.functions) == 1
+            @test fc.functions[1].complexity == 0
+
+            fc = file_cognitive_complexity(bad)
+            @test length(fc.functions) == 1
+            @test fc.functions[1].name == "nested"
+            @test fc.functions[1].complexity == 6
+            @test fc.total_complexity == 6
+        end
+
+        @testset "file_cognitive_complexity max_complexity" begin
+            fc = file_cognitive_complexity(bad; max_complexity = 3)
+            @test length(fc.functions) == 1
+
+            fc = file_cognitive_complexity(bad; max_complexity = 100)
+            @test isempty(fc.functions)
+            @test fc.total_complexity == 0
+        end
+
+        @testset "file not found" begin
+            @test_throws ArgumentError file_cognitive_complexity("nope.jl")
+        end
+
+        @testset "directory_cognitive_complexity" begin
+            results = directory_cognitive_complexity(tmpdir)
+            @test length(results) == 2
+
+            results =
+                directory_cognitive_complexity(tmpdir; max_complexity = 3)
+            @test length(results) == 1
+            @test occursin("bad.jl", results[1].path)
+
+            @test_throws ArgumentError directory_cognitive_complexity("missing")
+        end
+
+        @testset "check_cognitive_complexity violates" begin
+            @test_throws ErrorException check_cognitive_complexity(
+                bad;
+                max_complexity = 3,
+            )
+            v = check_cognitive_complexity(
+                bad;
+                max_complexity = 3,
+                throw_on_violation = false,
+            )
+            @test length(v) == 1
+        end
+
+        @testset "check_cognitive_complexity ok" begin
+            v = check_cognitive_complexity(good; max_complexity = 5)
+            @test isempty(v)
+        end
+
+        @testset "check_cognitive_complexity directory" begin
+            @test_throws ErrorException check_cognitive_complexity(
+                tmpdir;
+                max_complexity = 3,
+            )
+            v = check_cognitive_complexity(
+                tmpdir;
+                max_complexity = 3,
+                throw_on_violation = false,
+            )
+            @test length(v) == 1
+            @test occursin("bad.jl", v[1].path)
+        end
+
+        @testset "check_cognitive_complexity error message" begin
+            err = try
+                check_cognitive_complexity(bad; max_complexity = 3)
+                nothing
+            catch e
+                e
+            end
+            @test err !== nothing
+            @test occursin("Cognitive complexity violations", err.msg)
+            @test occursin("nested", err.msg)
+            @test occursin("complexity 6", err.msg)
+        end
+
+        @testset "check_cognitive_complexity path not found" begin
+            @test_throws ArgumentError check_cognitive_complexity("nope_path")
+        end
+    end
+end
+
+@testset "package_cognitive_complexity" begin
+    v = check_cognitive_complexity(
+        CodeComplexity;
+        max_complexity = 50,
+        throw_on_violation = false,
+    )
+    @test v isa Vector{FileCognitiveComplexity}
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Aqua
 @testset "CodeComplexity" begin
     include("cyclomatic_complexity_tests.jl")
     include("argument_counts_tests.jl")
+    include("cognitive_complexity_tests.jl")
 end
 
 @testset "Aqua" begin


### PR DESCRIPTION
## Summary

Implements a third complexity metric alongside the existing cyclomatic complexity and PLR0913-style argument counts: **cognitive complexity**, following G. Ann Campbell's [_Cognitive Complexity – a new way of measuring understandability_](https://www.sonarsource.com/resources/cognitive-complexity/) (SonarSource v1.7, 2023). Inspired by [`flake8-cognitive-complexity`](https://pypi.org/project/flake8-cognitive-complexity/).

Where cyclomatic complexity counts independent paths, cognitive complexity tries to estimate how hard a piece of code is to **understand**: it gives no base credit per method, charges extra for nested flow-break structures, and discounts shorthand structures.

### What counts

- Structural increments (subject to nesting): `if`, `for`, `while`, `catch`
- Hybrid increments (no nesting): `elseif`, `else`
- Each new sequence of like binary boolean operators (`&&` / `||`) — chains of the same op collapse to one
- `@goto`
- Direct recursion (function calls itself by name)
- Each level of nesting inside a structural/hybrid structure

`try` and `finally` blocks are free; only `catch` charges. Nested `function`, `macro`, and `->` lambdas raise the nesting level for their body without adding their own increment.

### Public API

Mirrors the existing cyclomatic surface, with explicit `cognitive_` names so the metrics can coexist:

- `cognitive_complexity(expr)` / `cognitive_complexity(code::String)`
- `cognitive_complexity_report(code; max_complexity=nothing)`
- `file_cognitive_complexity(path; max_complexity=nothing)`
- `directory_cognitive_complexity(dir; recursive=true, max_complexity=nothing)`
- `package_cognitive_complexity(pkg_or_name; max_complexity=nothing)`
- `check_cognitive_complexity(path_or_pkg; max_complexity=15, throw_on_violation=true)` — default 15 matches SonarSource's recommendation
- New types: `FunctionCognitiveComplexity` (`name`, `complexity`, `line`) and `FileCognitiveComplexity` (`path`, `functions`, `total_complexity`)

### Julia-specific notes (documented in the README)

- `cond ? a : b` and `if cond; a; else b end` parse to the same `:if` AST node, so the ternary is reported as `if/else` (`+1` for the `if` plus `+1` for the `else`) rather than the spec's single-increment ternary rule.
- Direct recursion is detected by name; **indirect recursion** and dotted names (e.g. `M.foo`) are not counted.
- Comprehensions/generators are walked transparently; nested `if`/`for` inside a comprehension don't add structural increments.

## Test plan

- [x] New `test/cognitive_complexity_tests.jl` covering trivial cases, every conditional shape, loops, boolean sequences, ternary, try/catch, recursion, `@goto`, lambdas/nested defs, the `_report` / file / directory / `check_*` flow, and error-message format.
- [x] Verified the spec's worked examples reproduce exactly: `sumOfPrimes`-style with `@goto` = 7, complex try/catch = 9, lambda + if = 2, `a && !(b && c)` = 2.
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — full suite passes (239 / 239 + 10 Aqua).
- [x] `JuliaFormatter.format(".")` clean.
- [x] No new linter diagnostics; existing cyclomatic and argument-count tests untouched and still passing.